### PR TITLE
Update libraries and Glimpse

### DIFF
--- a/exiv2-arch-flags-2.patch
+++ b/exiv2-arch-flags-2.patch
@@ -1,0 +1,37 @@
+diff --git a/cmake/compilerFlags.cmake b/cmake/compilerFlags.cmake
+index 96cc0c323..ae18583f8 100644
+--- a/cmake/compilerFlags.cmake
++++ b/cmake/compilerFlags.cmake
+@@ -1,4 +1,5 @@
+ # These flags applies to exiv2lib, the applications, and to the xmp code
++include(CheckCCompilerFlag)
+ 
+ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
+     if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+@@ -25,17 +26,16 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
+ 
+         # This fails under Fedora, MinGW GCC 8.3.0 and CYGWIN/MSYS 9.3.0
+         if (NOT (MINGW OR CMAKE_HOST_SOLARIS OR CYGWIN OR MSYS) )
+-            if (COMPILER_IS_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
+-                if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+-                    add_compile_options(-fstack-clash-protection -fcf-protection)
+-                else()
+-                    add_compile_options(-fstack-clash-protection)
+-                endif()
++	    check_c_compiler_flag(-fstack-clash-protection HAS_FSTACK_CLASH_PROTECTION)
++	    check_c_compiler_flag(-fcf-protection HAS_FCF_PROTECTION)
++	    check_c_compiler_flag(-fstack-protector-strong HAS_FSTACK_PROTECTOR_STRONG)
++	    if(HAS_FSTACK_CLASH_PROTECTION)
++                add_compile_options(-fstack-clash-protection)
+             endif()
+-
+-            if( (COMPILER_IS_GCC   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0) # Not in GCC 4.8
+-            OR  (COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 3.7) # Not in Clang 3.4.2
+-            )
++	    if(GCC_HAS_FCF_PROTECTION)
++		add_compile_options(-fcf-protection)
++	    endif()
++	    if(GCC_HAS_FSTACK_PROTECTOR_STRONG)
+                 add_compile_options(-fstack-protector-strong)
+             endif()
+         endif()

--- a/exiv2-arch-flags.patch
+++ b/exiv2-arch-flags.patch
@@ -1,0 +1,17 @@
+diff --git a/cmake/compilerFlags.cmake b/cmake/compilerFlags.cmake
+index aad1da17a..96cc0c323 100644
+--- a/cmake/compilerFlags.cmake
++++ b/cmake/compilerFlags.cmake
+@@ -26,7 +26,11 @@ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
+         # This fails under Fedora - MinGW - Gcc 8.3
+         if (NOT MINGW)
+             if (COMPILER_IS_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8.0)
+-                add_compile_options(-fstack-clash-protection -fcf-protection)
++                if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
++                    add_compile_options(-fstack-clash-protection -fcf-protection)
++                else()
++                    add_compile_options(-fstack-clash-protection)
++                endif()
+             endif()
+ 
+             if (COMPILER_IS_GCC OR (COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 3.7 ))

--- a/org.glimpse_editor.Glimpse.json
+++ b/org.glimpse_editor.Glimpse.json
@@ -96,8 +96,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://exiv2.org/builds/exiv2-0.27.3-Source.tar.gz",
-          "sha256": "a79f5613812aa21755d578a297874fb59a85101e793edc64ec2c6bd994e3e778"
+          "url": "https://exiv2.org/builds/exiv2-0.27.2-Source.tar.gz",
+          "sha256": "2652f56b912711327baff6dc0c90960818211cf7ab79bb5e1eb59320b78d153f"
         }
       ],
       "cleanup": [

--- a/org.glimpse_editor.Glimpse.json
+++ b/org.glimpse_editor.Glimpse.json
@@ -96,8 +96,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://exiv2.org/builds/exiv2-0.27.2-Source.tar.gz",
-          "sha256": "2652f56b912711327baff6dc0c90960818211cf7ab79bb5e1eb59320b78d153f"
+          "url": "https://exiv2.org/builds/exiv2-0.27.3-Source.tar.gz",
+          "sha256": "a79f5613812aa21755d578a297874fb59a85101e793edc64ec2c6bd994e3e778"
         }
       ],
       "cleanup": [
@@ -343,8 +343,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/mypaint/libmypaint/releases/download/v1.5.1/libmypaint-1.5.1.tar.xz",
-          "sha256": "aef8150a0c84ce2ff6fb24de8d5ffc564845d006f8bad7ed84ee32ed1dd90c2b"
+          "url": "https://github.com/mypaint/libmypaint/releases/download/v1.6.1/libmypaint-1.6.1.tar.xz",
+          "sha256": "741754f293f6b7668f941506da07cd7725629a793108bb31633fb6c3eae5315f"
         }
       ],
       "cleanup": [
@@ -384,6 +384,7 @@
           "type": "archive",
           "url": "https://github.com/xianyi/OpenBLAS/archive/v0.3.9.tar.gz",
           "sha256": "17d4677264dfbc4433e97076220adc79b050e4f8a083ea3f853a53af253bc380"
+
         }
       ],
       "cleanup": [

--- a/org.glimpse_editor.Glimpse.json
+++ b/org.glimpse_editor.Glimpse.json
@@ -95,9 +95,17 @@
       "builddir": true,
       "sources": [
         {
-          "type": "archive",
-          "url": "https://exiv2.org/builds/exiv2-0.27.2-Source.tar.gz",
-          "sha256": "2652f56b912711327baff6dc0c90960818211cf7ab79bb5e1eb59320b78d153f"
+            "type": "archive",
+            "url": "http://www.exiv2.org/builds/exiv2-0.27.3-Source.tar.gz",
+            "sha256": "a79f5613812aa21755d578a297874fb59a85101e793edc64ec2c6bd994e3e778"
+        },
+        {
+            "type": "patch",
+            "path": "exiv2-arch-flags.patch"
+        },
+        {
+            "type": "patch",
+            "path": "exiv2-arch-flags-2.patch"
         }
       ],
       "cleanup": [

--- a/org.glimpse_editor.Glimpse.json
+++ b/org.glimpse_editor.Glimpse.json
@@ -430,8 +430,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/strukturag/libde265/releases/download/v1.0.5/libde265-1.0.5.tar.gz",
-          "sha256": "e3f277d8903408615a5cc34718b391b83c97c646faea4f41da93bac5ee08a87f"
+          "url": "https://github.com/strukturag/libde265/releases/download/v1.0.8/libde265-1.0.8.tar.gz",
+          "sha256": "24c791dd334fa521762320ff54f0febfd3c09fc978880a8c5fbc40a88f21d905"
         }
       ],
       "cleanup": [
@@ -453,8 +453,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/strukturag/libheif/releases/download/v1.6.2/libheif-1.6.2.tar.gz",
-          "sha256": "bb229e855621deb374f61bee95c4642f60c2a2496bded35df3d3c42cc6d8eefc"
+          "url": "https://github.com/strukturag/libheif/releases/download/v1.12.0/libheif-1.12.0.tar.gz",
+          "sha256": "e1ac2abb354fdc8ccdca71363ebad7503ad731c84022cf460837f0839e171718"
         }
       ],
       "cleanup": [
@@ -472,8 +472,8 @@
         {
           "type": "git",
           "url": "https://gitlab.gnome.org/GNOME/babl.git",
-          "tag": "BABL_0_1_74",
-          "commit": "501c71495c9f4670ee066e3abe2ad6710e954084"
+          "tag": "BABL_0_1_86",
+          "commit": "92cfdacd51abb8bd6ff10edd800ef8b81e7ccf52"
         }
       ]
     },
@@ -506,7 +506,7 @@
         {
           "type": "git",
         "url": "https://github.com/glimpse-editor/glimpse",
-        "branch": "v0.2.0r2"
+        "branch": "v0.2.0"
         }
       ],
       "cleanup": [


### PR DESCRIPTION
Updating runtime breaks GEGL so I didn't do that.

Updated Glimpse.

Updated BABL and it seems to work, I'd like to know if this is expected or not.